### PR TITLE
Struct buffers

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 [[CubicEoSDatabase]]
 deps = ["DelimitedFiles"]
-git-tree-sha1 = "d1dfa611195badc7a7b85137b9b6b0f2ca703d86"
+git-tree-sha1 = "ebf538477f45010d41376953fe3e76e0d843ba02"
 repo-rev = "master"
 repo-url = "https://gitlab.com/stepanzh/cubiceosdatabase.jl"
 uuid = "8742253c-1987-415f-b31d-1ec9670d9ed7"
@@ -14,7 +14,7 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DescentMethods]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "efc3f2f6484b4a039b553f8bdc80a063dd5c1feb"
+git-tree-sha1 = "93169c57a53a415c918a149b5339474fe5818409"
 repo-rev = "chol_bfgs"
 repo-url = "https://github.com/vvpisarev/DescentMethods.jl"
 uuid = "f4becde8-b16e-4b5a-8f91-16ef0c22c8bc"

--- a/src/CubicEoS.jl
+++ b/src/CubicEoS.jl
@@ -1,5 +1,12 @@
 module CubicEoS
 
+export AbstractEoSComponent, AbstractEoSMixture
+export BrusilovskyEoSComponent, BrusilovskyEoSMixture, thermo_buffer
+export molar_mass, carbon_number, name, describe, load, components # Do we need to export `load`?
+export ncomponents, pressure, wilson_saturation_pressure, compressibility
+export log_c_activity!, log_c_activity, log_c_activity_wj!, log_c_activity_wj
+export vt_stability, vt_stability_buffer
+
 include("constants.jl")
 include("types.jl")
 include("interface.jl")

--- a/src/basic_thermo.jl
+++ b/src/basic_thermo.jl
@@ -26,7 +26,8 @@ end
 """
     pressure(substance, υ, RT)
 
-Compute pressure (Pa) of `substance` at given molar volume `υ` (m³ mol⁻¹) and thermal energy `RT` (J mol⁻¹).
+Compute pressure (Pa) of `substance` at given molar volume `υ` (m³ mol⁻¹) and
+thermal energy `RT` (J mol⁻¹).
 """
 function pressure(substance::BrusilovskyEoSComponent, υ::Real, RT::Real)
     acoeff = a_coef(substance, RT)
@@ -39,7 +40,8 @@ end
 """
     pressure(substance, nmol, V, RT)
 
-Compute pressure (Pa) of `substance` at given number of moles `nmol` (mol), total volume `V` (m³) and thermal energy `RT` (J mol⁻¹).
+Compute pressure (Pa) of `substance` at given number of moles `nmol` (mol),
+total volume `V` (m³) and thermal energy `RT` (J mol⁻¹).
 """
 function pressure(substance::BrusilovskyEoSComponent, nmol::Real, V::Real, RT::Real)
     acoeff = a_coef(substance, RT)
@@ -53,7 +55,8 @@ end
 """
     pressure(substance; nmol = 1, volume, temperature)
 
-Computes pressure (Pa) of `substance` at given number of moles `nmol` (mol), total volume (m³) and temperature (K).
+Compute pressure (Pa) of `substance` at given number of moles `nmol` (mol),
+total volume (m³) and temperature (K).
 """
 function pressure(
     substance::BrusilovskyEoSComponent;
@@ -68,7 +71,7 @@ end
 """
     wilson_saturation_pressure(substance, RT)
 
-Returns approximate saturation pressure of `substance` at `RT` (J mol⁻¹).
+Return approximate saturation pressure of `substance` at `RT` (J mol⁻¹).
 
 Reference: Brusilovsky2002 [p 272, eq 5.4]
 """
@@ -171,7 +174,7 @@ function __eos_parameters_impl__(
 end
 
 """
-    pressure(mixture, nmol, volume, RT[, buf])
+    pressure(mixture, nmol, volume, RT[; buf])
 
 Return pressure (Pa) of `mixture` at given
 
@@ -185,6 +188,8 @@ Allocations may be avoided by passing `buf`.
 - `buf::Union{BrusilovskyThermoBuffer,NamedTuple,AbstractDict}`: Buffer for intermediate
     calculations. In case of `NamedTuple` and `AbstractDict` `buf` should contain `buf[:ai]`
     `NC = ncomponents(mixture)` vector and `buf[:aij]` NCxNC matrix.
+
+See also: [`thermo_buffer`](@ref)
 """
 function pressure(
     mixture::BrusilovskyEoSMixture,
@@ -198,7 +203,7 @@ function pressure(
 end
 
 """
-    compressibility(mixture, χ, P, RT[, phase='g'])
+    compressibility(mixture, χ, P, RT[, phase='g'][; buf])
 
 Compute compressibility (z-factor) of `mixture` in `phase` at given
 
@@ -208,8 +213,13 @@ Compute compressibility (z-factor) of `mixture` in `phase` at given
 
 # Optional arguments
 
-- `phase::AbstractChar='g'` - specifies phase of `mixture` (`'g'` for gas, `'l'` for liquid)
-- `buffer::BrusilovskyEoSMixtureBuffer` - buffer for intermediate calculations
+- `phase::AbstractChar='g'`: specifies phase of `mixture` (`'g'` for gas, `'l'` for liquid)
+
+# Keywords:
+- `buf::Union{BrusilovskyThermoBuffer,NamedTuple,AbstractDict}`: buffer for intermediate
+    calculations (see [`pressure`](@ref))
+
+See also: [`pressure`](@ref)
 """
 function compressibility(
     mix::BrusilovskyEoSMixture,

--- a/src/basic_thermo.jl
+++ b/src/basic_thermo.jl
@@ -104,9 +104,7 @@ composition `nmol` and thermal energy `RT`. Allocations may be avoided by passin
 - `RT::Real`: Thermal energy (J mol⁻¹)
 
 # Keywords
-- `buf::Union{BrusilovskyThermoBuffer,NamedTuple,AbstractDict}`: Buffer for intermediate
-    calculations. In case of `NamedTuple` and `AbstractDict` `buf` should contain `buf[:ai]`
-    `NC = ncomponents(mixture)` vector and `buf[:aij]` NCxNC matrix.
+- `buf`: see ?pressure(mixture)
 """
 function eos_parameters(
     mixture::BrusilovskyEoSMixture{T},
@@ -170,26 +168,29 @@ function __eos_parameters_impl__(
 end
 
 """
-    pressure(mixture, χ, υ, RT[, buffer])
+    pressure(mixture, nmol, volume, RT[, buf])
 
 Returns pressure (Pa) of `mixture` at given
 
-- composition in molar parts `χ` (dimless)
-- molar volume `υ` (m³ mol⁻¹)
-- thermal energy `RT` (J mol⁻¹)
+- `nmol::AbstractVector`: composition (molar parts) or number of moles (mol)
+- `volume::Real`: molar volume (m³ mol⁻¹) or volume (m³)
+- `RT::Real`: thermal energy (J mol⁻¹)
 
-# Keyword arguments
+Allocations may be avoided by passing `buf`.
 
-- `aij::AbstractMatrix`, `ai::AbstractVector` - buffers for intermediate calculations
+# Keywords
+- `buf::Union{BrusilovskyThermoBuffer,NamedTuple,AbstractDict}`: Buffer for intermediate
+    calculations. In case of `NamedTuple` and `AbstractDict` `buf` should contain `buf[:ai]`
+    `NC = ncomponents(mixture)` vector and `buf[:aij]` NCxNC matrix.
 """
 function pressure(
     mixture::BrusilovskyEoSMixture,
     nmol::AbstractVector,
-    volume,
-    RT;
-    buf = NamedTuple()
+    volume::Real,
+    RT::Real;
+    buf = NamedTuple(),
 )
-    Am, Bm, Cm, Dm = eos_parameters(mixture, nmol, RT; buf = buf)
+    Am, Bm, Cm, Dm, _ = eos_parameters(mixture, nmol, RT; buf = buf)
     return sum(nmol) * RT / (volume - Bm) - Am/((volume + Cm) * (volume + Dm))
 end
 

--- a/src/basic_thermo.jl
+++ b/src/basic_thermo.jl
@@ -3,8 +3,6 @@ Basic thermodynamic properties
 =#
 using LinearAlgebra
 
-export ncomponents, pressure, wilson_saturation_pressure, compressibility
-
 include("solvecubic.jl")
 
 @inline ncomponents(mix::BrusilovskyEoSMixture) = length(mix.components)

--- a/src/basic_thermo.jl
+++ b/src/basic_thermo.jl
@@ -99,9 +99,9 @@ function eos_parameters(
     mixture::BrusilovskyEoSMixture{T},
     nmol::AbstractVector{<:Real},
     RT::Real;
-    buffers...
+    kwargs...
 ) where {T}
-
+    buffers = kwargs.data
     nc = length(nmol)
     aij = haskey(buffers, :aij) ? buffers[:aij] : Matrix{T}(undef, nc, nc)
     ai = haskey(buffers, :ai) ? buffers[:ai] : Vector{T}(undef, nc)
@@ -140,10 +140,10 @@ function pressure(
     nmol::AbstractVector{<:Real},
     volume::Real,
     RT::Real;
-    buffers...
+    kwargs...
 )
 
-    Am, Bm, Cm, Dm = eos_parameters(mixture, nmol, RT; buffers...)
+    Am, Bm, Cm, Dm = eos_parameters(mixture, nmol, RT; kwargs...)
     return sum(nmol) * RT / (volume - Bm) - Am/((volume + Cm) * (volume + Dm))
 end
 
@@ -166,13 +166,14 @@ function compressibility(
     χ::AbstractVector{<:Real},
     P::Real,
     RT::Real,
-    phase::AbstractChar='g'
+    phase::AbstractChar='g';
+    kwargs...
 )
 
     phase in ('g', 'l') || throw(DomainError(repr(phase), "Phase must be 'g' or 'l'"))
 
     ntotal = sum(χ)
-    am, bm, cm, dm = eos_parameters(mix, χ, RT)
+    am, bm, cm, dm = eos_parameters(mix, χ, RT; kwargs...)
     prt = P / (RT * ntotal)
     am *= prt / (RT * ntotal)
     bm *= prt

--- a/src/chempotential.jl
+++ b/src/chempotential.jl
@@ -2,10 +2,12 @@
 Functions to compute chemical potential-related characteristics
 =#
 
-"""
-    log_activity(mixture, nmol, volume, RT; kwargs...)
+export log_c_activity!, log_c_activity, log_c_activity_wj!, log_c_activity_wj
 
-Return vector of ln(c_a) - logarithm of activity coefficient
+"""
+    log_c_activity(mixture, nmol, volume, RT; buf = (;))
+
+Return vector of ln(c_a) - logarithm of activity coefficients
 for components of `mixture` at given `nmol`, `volume`, `RT`.
 If buffers are provided as keyword arguments, their contents
 are modified during the intermediate calculations.
@@ -24,29 +26,67 @@ of the components at given number of moles, volume and temperature
 
 # Keyword arguments
 
-- `log_a::AbstractVector`: vector for storing the answer. Specify it to avoid allocation
-- `ai::AbstractVector`: buffer for intermediate calculations
-- `aij::AbstractMatrix`: buffers for intermediate calculations
+- `buf::Union{NamedTuple, AbstractDict, BrusilovskyThermoBuffer}`: buffers for intermediate
+calculations
 
 See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
 """
-function log_activity(
+function log_c_activity(
     mix::BrusilovskyEoSMixture{T},
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    kwargs...
+    buf = NamedTuple()
 ) where {T}
 
     nc = ncomponents(mix)
+    log_ca = Vector{T}(undef, nc)
+
+    return log_c_activity!(log_ca, mix, nmol, volume, RT; buf = buf)
+end
+
+"""
+    log_c_activity!(log_ca, mixture, nmol, volume, RT; buf = (;))
+
+Return vector of ln(c_a) - logarithm of activity coefficients
+for components of `mixture` at given `nmol`, `volume`, `RT`.
+If buffers are provided as keyword arguments, their contents
+are modified during the intermediate calculations. The answer is stored
+in `log_ca`.
+
+# Arguments
+
+- `log_ca::AbstractVector`: buffer to store the result
+- `mix::BrusilovskyEoSMixture`: mixture
+- `nmol::AbstractVector`: amount of each component (mol)
+- `volume`: volume of the mixture (m³)
+- `RT`: thermal energy (J/mol)
+
+# Returns
+
+- `AbstractVector`: the logarithms of activity coefficients
+of the components at given number of moles, volume and temperature
+
+# Keyword arguments
+
+- `buf::Union{BrusilovskyThermoBuffer, NamedTuple, AbstractDict}`: buffers for intermediate
+calculations
+
+See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
+"""
+function log_c_activity!(
+    log_ca::AbstractVector,
+    mix::BrusilovskyEoSMixture,
+    nmol::AbstractVector,
+    volume,
+    RT;
+    buf = NamedTuple()
+)
+    nc = ncomponents(mix)
     ∑mol = sum(nmol)
 
-    buffers = kwargs.data
-    aij = haskey(buffers, :aij) ? buffers[:aij] : Matrix{T}(undef, nc, nc)
-    log_a = haskey(buffers, :log_a) ? buffers[:log_a] : Vector{T}(undef, nc)
-
     # коэффициенты вычислены для состава в [моль]
-    A, B, C, D, aij = eos_parameters(mix, nmol, RT; aij = aij, ai = log_a)
+    A, B, C, D, aij = eos_parameters(mix, nmol, RT; buf = buf)
 
     VmB = volume - B
     VpC = volume + C
@@ -68,15 +108,15 @@ function log_activity(
         # прежний код использовал sum( генератор с for in eachindex ) - давал 2 аллокации
         ∂A = 2 * dot(nmol, @view aij[:,i])
 
-        log_a[i] = -log_VmBbyV + b * ∑molbyVmB
-        brackets = (∂A / A - (c - d)/CmD) * log_VpCbyVpD + (c/VpC - d/VpD)
-        log_a[i] -= AbyRTCmD * brackets
+        log_ca[i] = -log_VmBbyV + b * ∑molbyVmB
+        brackets = (∂A / A - (c - d) / CmD) * log_VpCbyVpD + (c / VpC - d / VpD)
+        log_ca[i] -= AbyRTCmD * brackets
     end
-    return log_a
+    return log_ca
 end
 
 """
-    log_activity_wj(mixture, nmol, volume, RT; kwargs...)
+    log_activity_wj(mixture, nmol, volume, RT; buf = (;))
 
 Return vector of ln(c_a) - logarithm of activity coefficient
 for components of `mixture` at given `nmol`, `volume`, `RT` -
@@ -98,27 +138,48 @@ of the components at given number of moles, volume and temperature
 
 # Keyword arguments
 
-- `log_a::AbstractVector`: vector for storing the answer. Specify it to avoid allocation
-- `jacobian::AbstractMatrix`: vector for storing the jacobian. Specify it to avoid allocation
-- `aux1::AbstractVector`: buffer for intermediate calculations
-- `aux2::AbstractVector`: buffer for intermediate calculations
+- `buf::Union{BrusilovskyThermoBuffer, NamedTuple, AbstractDict}`: buffers for intermediate
+calculations
 """
-function log_activity_wj(
+function log_c_activity_wj(
     mix::BrusilovskyEoSMixture{T},
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    kwargs...
+    buf = nothing
 ) where {T}
     nc = ncomponents(mix)
-    buffers = kwargs.data
-    jacobian = haskey(buffers, :jacobian) ? buffers[:jacobian] : Matrix{T}(undef, nc, nc)
-    log_a = haskey(buffers, :log_a) ? buffers[:log_a] : Vector{T}(undef, nc)
-    aux1 = haskey(buffers, :aux1) ? buffers[:aux1] : Vector{T}(undef, nc)
-    aux2 = haskey(buffers, :aux2) ? buffers[:aux2] : Vector{T}(undef, nc)
+    log_ca = Vector{T}(undef, nc)
+    jacobian = similar(log_ca, (nc, nc))
+    return log_c_activity_wj!(log_ca, jacobian, mix, nmol, volume, RT; buf = buf)
+end
 
-    A, B, C, D, aij = eos_parameters(mix, nmol, RT; aij = jacobian, ai = aux1)
+function log_c_activity_wj!(
+    log_ca::AbstractVector,
+    jacobian::AbstractMatrix,
+    mix::BrusilovskyEoSMixture,
+    nmol::AbstractVector,
+    volume::Real,
+    RT::Real;
+    buf = nothing
+)
+    return __log_c_activity_wj_impl__(log_ca, jacobian, mix, nmol, volume, RT, buf)
+end
 
+function __log_c_activity_wj_impl__(
+    log_ca::AbstractVector,
+    jacobian::AbstractMatrix,
+    mix::BrusilovskyEoSMixture,
+    nmol::AbstractVector,
+    volume::Real,
+    RT::Real,
+    buf::BrusilovskyThermoBuffer
+)
+    A, B, C, D, aij = eos_parameters(mix, nmol, RT; buf = buf)
+
+    aux1 = buf.vec1
+    aux2 = buf.vec2
+    nc = ncomponents(mix)
     V = volume
     ntotal = sum(nmol)
 
@@ -132,28 +193,25 @@ function log_activity_wj(
     log_VpCbyVpD = log(VpC / VpD)
     log2 = log1p(CmD / (V + D)) / (RT * CmD)
 
-    aij = jacobian
+    @inbounds map!(aux1, 1:nc) do i
+        mix[i].b / VmB
+    end
+    log_ca .= aux1 .* ntotal .- log_VmBbyV
+    jacobian .= aux1 .+ aux1' .+ ntotal .* aux1 .* aux1'
     mul!(aux1, aij, nmol)
     @inbounds map!(aux2, 1:nc) do i
         mix[i].c - mix[i].d
     end
-    log_a .= (-AbyRTCmD * log_VpCbyVpD) .* (2 .* aux1 ./ A .- aux2 ./ CmD)
-    jacobian .= (-2 * log2) .* ((A / CmD^2) .* aux2 .* aux2' .+ aij)
+    log_ca .-= AbyRTCmD .* log_VpCbyVpD .* (2 .* aux1 ./ A .- aux2 ./ CmD)
+    jacobian .-= (2 * log2) .* ((A / CmD^2) .* aux2 .* aux2' .+ aij)
     jacobian .+= (2 * log2 / CmD) .* (aux2 .* aux1' .+ aux1 .* aux2')
 
-    aux1 .= aux1 .* (2 / (RT * CmD)) .- aux2 .* (A / (RT * CmD^2))
+    aux1 .= 2 .* aux1 ./ (RT * CmD) .- aux2 .* (A / (RT * CmD^2))
     @inbounds map!(aux2, 1:nc) do i
         mix[i].c / VpC - mix[i].d / VpD
     end
-    log_a .-= AbyRTCmD .* aux2
+    log_ca .-= AbyRTCmD .* aux2
     jacobian .-= aux1 .* aux2'.+ aux2 .* aux1'
-
-    @inbounds map!(aux1, 1:nc) do i
-        mix[i].b / VmB
-    end
-    log_a .+= aux1 .* ntotal .- log_VmBbyV
-    jacobian .+= aux1 .+ aux1' .+ ntotal .* aux1 .* aux1'
-
     @inbounds map!(aux1, 1:nc) do i
         mix[i].d / VpD
     end
@@ -162,5 +220,18 @@ function log_activity_wj(
     end
 
     jacobian .-= AbyRTCmD .* (aux1 .* aux1' .- aux2 .* aux2')
-    return log_a, jacobian
+    return log_ca, jacobian
+end
+
+function __log_c_activity_wj_impl__(
+    log_ca::AbstractVector,
+    jacobian::AbstractMatrix,
+    mix::BrusilovskyEoSMixture,
+    nmol::AbstractVector,
+    volume::Real,
+    RT::Real,
+    buf::Nothing
+)
+    thermo_buf = BrusilovskyThermoBuffer(mix)
+    return __log_c_activity_wj_impl__(log_ca, jacobian, mix, nmol, volume, RT, thermo_buf)
 end

--- a/src/chempotential.jl
+++ b/src/chempotential.jl
@@ -3,19 +3,30 @@ Functions to compute chemical potential-related characteristics
 =#
 
 """
-    log_activity!([log_a_, ai_, aij_,] mixture, nmol, volume, RT)
+    log_activity(mixture, nmol, volume, RT; kwargs...)
 
-Returns vector of ln(c_a) - logarithm of activity coefficient
-for components of `mixture` at given
+Return vector of ln(c_a) - logarithm of activity coefficient
+for components of `mixture` at given `nmol`, `volume`, `RT`.
+If buffers are provided as keyword arguments, their contents
+are modified during the intermediate calculations.
 
-- amount of each component `N` (mol)
-- volume `V` (m³)
-- thermal energy `RT`
+# Arguments
+
+- `mix`: mixture
+- `nmol::AbstractVector`: amount of each component (mol)
+- `volume`: volume of the mixture (m³)
+- `RT`: thermal energy (J/mol)
+
+# Returns
+
+- `AbstractVector`: the logarithms of activity coefficients
+of the components at given number of moles, volume and temperature
 
 # Keyword arguments
 
-- `log_a::AbstractVector` - vector for storing answer. Specify it to avoid allocation
-- `ai::AbstractVector`, `aij::AbstractMatrix` - buffers for intermediate calculations
+- `log_a::AbstractVector`: vector for storing the answer. Specify it to avoid allocation
+- `ai::AbstractVector`: buffer for intermediate calculations
+- `aij::AbstractMatrix`: buffers for intermediate calculations
 
 See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
 """
@@ -64,6 +75,34 @@ function log_activity(
     return log_a
 end
 
+"""
+    log_activity_wj(mixture, nmol, volume, RT; kwargs...)
+
+Return vector of ln(c_a) - logarithm of activity coefficient
+for components of `mixture` at given `nmol`, `volume`, `RT` -
+and the jacobian ∂ln(c_a[i]) / ∂n[j].
+If buffers are provided as keyword arguments, their contents
+are modified during the intermediate calculations.
+
+# Arguments
+
+- `mix`: mixture
+- `nmol::AbstractVector`: amount of each component (mol)
+- `volume`: volume of the mixture (m³)
+- `RT`: thermal energy (J/mol)
+
+# Returns
+
+- `AbstractVector`: the logarithms of activity coefficients
+of the components at given number of moles, volume and temperature
+
+# Keyword arguments
+
+- `log_a::AbstractVector`: vector for storing the answer. Specify it to avoid allocation
+- `jacobian::AbstractMatrix`: vector for storing the jacobian. Specify it to avoid allocation
+- `aux1::AbstractVector`: buffer for intermediate calculations
+- `aux2::AbstractVector`: buffer for intermediate calculations
+"""
 function log_activity_wj(
     mix::BrusilovskyEoSMixture{T},
     nmol::AbstractVector,

--- a/src/chempotential.jl
+++ b/src/chempotential.jl
@@ -2,8 +2,6 @@
 Functions to compute chemical potential-related characteristics
 =#
 
-export log_c_activity!, log_c_activity, log_c_activity_wj!, log_c_activity_wj
-
 """
     log_c_activity(mixture, nmol, volume, RT; buf = (;))
 
@@ -116,7 +114,7 @@ function log_c_activity!(
 end
 
 """
-    log_activity_wj(mixture, nmol, volume, RT; buf = (;))
+    log_activity_wj(mixture, nmol, volume, RT[; buf])
 
 Return vector of ln(c_a) - logarithm of activity coefficient
 for components of `mixture` at given `nmol`, `volume`, `RT` -
@@ -133,12 +131,13 @@ are modified during the intermediate calculations.
 
 # Returns
 
-- `AbstractVector`: the logarithms of activity coefficients
-of the components at given number of moles, volume and temperature
+- `Tuple{AbstractVector,AbstractMatrix}`: the logarithms of activity coefficients
+of the components at given number of moles, volume and temperature, and the jacobian
+matrix ∂ln(c_a[i]) / ∂n[j].
 
 # Keyword arguments
 
-- `buf::Union{BrusilovskyThermoBuffer, NamedTuple, AbstractDict}`: buffers for intermediate
+- `buf::BrusilovskyThermoBuffer`: buffers for intermediate
 calculations
 """
 function log_c_activity_wj(
@@ -154,6 +153,36 @@ function log_c_activity_wj(
     return log_c_activity_wj!(log_ca, jacobian, mix, nmol, volume, RT; buf = buf)
 end
 
+"""
+    log_activity_wj!(log_ca, jacobian, mixture, nmol, volume, RT[; buf])
+
+Return vector of ln(c_a) - logarithm of activity coefficient
+for components of `mixture` at given `nmol`, `volume`, `RT` -
+and the jacobian ∂ln(c_a[i]) / ∂n[j]. The first two arguments get overwritten
+by the result.
+If buffers are provided as keyword arguments, their contents
+are modified during the intermediate calculations.
+
+# Arguments
+
+- `log_ca::AbstractVector`: a vector to store the activity coefficients
+- `jacobian::AbstractMatrix`: a matrix to store ∂ln(c_a[i]) / ∂n[j]
+- `mix`: mixture
+- `nmol::AbstractVector`: amount of each component (mol)
+- `volume`: volume of the mixture (m³)
+- `RT`: thermal energy (J/mol)
+
+# Returns
+
+- `Tuple{AbstractVector,AbstractMatrix}`: the logarithms of activity coefficients
+of the components at given number of moles, volume and temperature, and the jacobian
+matrix ∂ln(c_a[i]) / ∂n[j]. The values are aliases for the first two arguments.
+
+# Keyword arguments
+
+- `buf::BrusilovskyThermoBuffer`: buffers for intermediate
+calculations
+"""
 function log_c_activity_wj!(
     log_ca::AbstractVector,
     jacobian::AbstractMatrix,

--- a/src/chempotential.jl
+++ b/src/chempotential.jl
@@ -3,7 +3,7 @@ Functions to compute chemical potential-related characteristics
 =#
 
 """
-    log_c_activity(mixture, nmol, volume, RT; buf = (;))
+    log_c_activity(mixture, nmol, volume, RT[; buf])
 
 Return vector of ln(c_a) - logarithm of activity coefficients
 for components of `mixture` at given `nmol`, `volume`, `RT`.
@@ -20,7 +20,7 @@ are modified during the intermediate calculations.
 # Keywords
 
 - `buf::Union{NamedTuple, AbstractDict, BrusilovskyThermoBuffer}`: buffers for intermediate
-    calculations
+    calculations (see [`pressure`](@ref))
 
 # Returns
 
@@ -28,6 +28,7 @@ are modified during the intermediate calculations.
     number of moles, volume and temperature
 
 See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
+
 See also: [`log_c_activity!`](@ref), [`log_c_activity_wj`](@ref), [`log_c_activity_wj!`](@ref)
 """
 function log_c_activity(
@@ -45,7 +46,7 @@ function log_c_activity(
 end
 
 """
-    log_c_activity!(log_ca, mixture, nmol, volume, RT; buf = (;))
+    log_c_activity!(log_ca, mixture, nmol, volume, RT[; buf])
 
 Return vector of ln(c_a) - logarithm of activity coefficients
 for components of `mixture` at given `nmol`, `volume`, `RT`.
@@ -64,7 +65,7 @@ in `log_ca`.
 # Keywords
 
 - `buf::Union{BrusilovskyThermoBuffer, NamedTuple, AbstractDict}`: buffers for intermediate
-calculations
+    calculations (see [`pressure`](@ref))
 
 # Returns
 
@@ -72,6 +73,7 @@ calculations
     number of moles, volume and temperature
 
 See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
+
 See also: [`log_c_activity`](@ref), [`log_c_activity_wj`](@ref), [`log_c_activity_wj!`](@ref)
 """
 function log_c_activity!(
@@ -131,15 +133,16 @@ are modified during the intermediate calculations.
 - `volume`: volume of the mixture (m³)
 - `RT`: thermal energy (J/mol)
 
+# Keywords
+
+- `buf::BrusilovskyThermoBuffer`: buffers for intermediate calculations
+    (see [`thermo_buffer`](@ref))
+
 # Returns
 
 - `Tuple{AbstractVector,AbstractMatrix}`: the logarithms of activity coefficients
 of the components at given number of moles, volume and temperature, and the jacobian
 matrix ∂ln(c_a[i]) / ∂n[j].
-
-# Keyword arguments
-
-- `buf::BrusilovskyThermoBuffer`: buffers for intermediate calculations
 
 See also: [`log_c_activity`](@ref), [`log_c_activity!`](@ref), [`log_c_activity_wj!`](@ref)
 """
@@ -175,15 +178,16 @@ are modified during the intermediate calculations.
 - `volume`: volume of the mixture (m³)
 - `RT`: thermal energy (J/mol)
 
+# Keywords
+
+- `buf::BrusilovskyThermoBuffer`: buffers for intermediate calculations
+    (see [`thermo_buffer`](@ref))
+
 # Returns
 
 - `Tuple{AbstractVector,AbstractMatrix}`: the logarithms of activity coefficients
 of the components at given number of moles, volume and temperature, and the jacobian
 matrix ∂ln(c_a[i]) / ∂n[j]. The values are aliases for the first two arguments.
-
-# Keyword arguments
-
-- `buf::BrusilovskyThermoBuffer`: buffers for intermediate calculations
 
 See also: [`log_c_activity`](@ref), [`log_c_activity!`](@ref), [`log_c_activity_wj`](@ref)
 """

--- a/src/chempotential.jl
+++ b/src/chempotential.jl
@@ -24,12 +24,13 @@ function log_activity(
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    buffers...
+    kwargs...
 ) where {T}
 
     nc = ncomponents(mix)
     ∑mol = sum(nmol)
 
+    buffers = kwargs.data
     aij = haskey(buffers, :aij) ? buffers[:aij] : Matrix{T}(undef, nc, nc)
     ai = haskey(buffers, :ai) ? buffers[:ai] : Vector{T}(undef, nc)
     log_a = haskey(buffers, :log_a) ? buffers[:log_a] : Vector{T}(undef, nc)
@@ -69,9 +70,10 @@ function log_activity_wj(
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    buffers...
+    kwargs...
 ) where {T}
     nc = ncomponents(mix)
+    buffers = kwargs.data
     jacobian = haskey(buffers, :jacobian) ? buffers[:jacobian] : Matrix{T}(undef, nc, nc)
     aij = haskey(buffers, :aij) ? buffers[:aij] : Matrix{T}(undef, nc, nc)
     log_a = haskey(buffers, :log_a) ? buffers[:log_a] : Vector{T}(undef, nc)

--- a/src/chempotential.jl
+++ b/src/chempotential.jl
@@ -17,24 +17,25 @@ are modified during the intermediate calculations.
 - `volume`: volume of the mixture (m³)
 - `RT`: thermal energy (J/mol)
 
-# Returns
-
-- `AbstractVector`: the logarithms of activity coefficients
-of the components at given number of moles, volume and temperature
-
-# Keyword arguments
+# Keywords
 
 - `buf::Union{NamedTuple, AbstractDict, BrusilovskyThermoBuffer}`: buffers for intermediate
-calculations
+    calculations
+
+# Returns
+
+- `AbstractVector`: the logarithms of activity coefficients of the components at given
+    number of moles, volume and temperature
 
 See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
+See also: [`log_c_activity!`](@ref), [`log_c_activity_wj`](@ref), [`log_c_activity_wj!`](@ref)
 """
 function log_c_activity(
     mix::BrusilovskyEoSMixture{T},
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    buf = NamedTuple()
+    buf = NamedTuple(),
 ) where {T}
 
     nc = ncomponents(mix)
@@ -60,17 +61,18 @@ in `log_ca`.
 - `volume`: volume of the mixture (m³)
 - `RT`: thermal energy (J/mol)
 
-# Returns
-
-- `AbstractVector`: the logarithms of activity coefficients
-of the components at given number of moles, volume and temperature
-
-# Keyword arguments
+# Keywords
 
 - `buf::Union{BrusilovskyThermoBuffer, NamedTuple, AbstractDict}`: buffers for intermediate
 calculations
 
+# Returns
+
+- `AbstractVector`: the logarithms of activity coefficients of the components at given
+    number of moles, volume and temperature
+
 See (Jirí Mikyska, Abbas Firoozabadi // 10.1002/aic.12387)
+See also: [`log_c_activity`](@ref), [`log_c_activity_wj`](@ref), [`log_c_activity_wj!`](@ref)
 """
 function log_c_activity!(
     log_ca::AbstractVector,
@@ -78,7 +80,7 @@ function log_c_activity!(
     nmol::AbstractVector,
     volume,
     RT;
-    buf = NamedTuple()
+    buf = NamedTuple(),
 )
     nc = ncomponents(mix)
     ∑mol = sum(nmol)
@@ -114,7 +116,7 @@ function log_c_activity!(
 end
 
 """
-    log_activity_wj(mixture, nmol, volume, RT[; buf])
+    log_c_activity_wj(mixture, nmol, volume, RT[; buf])
 
 Return vector of ln(c_a) - logarithm of activity coefficient
 for components of `mixture` at given `nmol`, `volume`, `RT` -
@@ -137,15 +139,16 @@ matrix ∂ln(c_a[i]) / ∂n[j].
 
 # Keyword arguments
 
-- `buf::BrusilovskyThermoBuffer`: buffers for intermediate
-calculations
+- `buf::BrusilovskyThermoBuffer`: buffers for intermediate calculations
+
+See also: [`log_c_activity`](@ref), [`log_c_activity!`](@ref), [`log_c_activity_wj!`](@ref)
 """
 function log_c_activity_wj(
     mix::BrusilovskyEoSMixture{T},
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    buf = nothing
+    buf::BrusilovskyThermoBuffer = thermo_buffer(mix),
 ) where {T}
     nc = ncomponents(mix)
     log_ca = Vector{T}(undef, nc)
@@ -180,8 +183,9 @@ matrix ∂ln(c_a[i]) / ∂n[j]. The values are aliases for the first two argumen
 
 # Keyword arguments
 
-- `buf::BrusilovskyThermoBuffer`: buffers for intermediate
-calculations
+- `buf::BrusilovskyThermoBuffer`: buffers for intermediate calculations
+
+See also: [`log_c_activity`](@ref), [`log_c_activity!`](@ref), [`log_c_activity_wj`](@ref)
 """
 function log_c_activity_wj!(
     log_ca::AbstractVector,
@@ -190,7 +194,7 @@ function log_c_activity_wj!(
     nmol::AbstractVector,
     volume::Real,
     RT::Real;
-    buf = nothing
+    buf::BrusilovskyThermoBuffer = thermo_buffer(mix),
 )
     return __log_c_activity_wj_impl__(log_ca, jacobian, mix, nmol, volume, RT, buf)
 end
@@ -200,9 +204,9 @@ function __log_c_activity_wj_impl__(
     jacobian::AbstractMatrix,
     mix::BrusilovskyEoSMixture,
     nmol::AbstractVector,
-    volume::Real,
-    RT::Real,
-    buf::BrusilovskyThermoBuffer
+    volume,
+    RT,
+    buf::BrusilovskyThermoBuffer,
 )
     A, B, C, D, aij = eos_parameters(mix, nmol, RT; buf = buf)
 
@@ -250,17 +254,4 @@ function __log_c_activity_wj_impl__(
 
     jacobian .-= AbyRTCmD .* (aux1 .* aux1' .- aux2 .* aux2')
     return log_ca, jacobian
-end
-
-function __log_c_activity_wj_impl__(
-    log_ca::AbstractVector,
-    jacobian::AbstractMatrix,
-    mix::BrusilovskyEoSMixture,
-    nmol::AbstractVector,
-    volume::Real,
-    RT::Real,
-    buf::Nothing
-)
-    thermo_buf = BrusilovskyThermoBuffer(mix)
-    return __log_c_activity_wj_impl__(log_ca, jacobian, mix, nmol, volume, RT, thermo_buf)
 end

--- a/src/dbload.jl
+++ b/src/dbload.jl
@@ -68,7 +68,6 @@ function __load_brusilovsky_comp__(
     critical_omega::AbstractString,
     psi::AbstractString
 )
-
     Omegac  = 0.75001                       # Table (4.14)
     Zc      = 0.3357 - 0.0294 * acentric    # 4.203
     if acentric < 0.4489
@@ -140,7 +139,6 @@ function load(
     component_dbs = (Data.martinez(), Data.brusilovsky_comp()),
     mix_eos_db::MixtureDatabase = Data.brusilovsky_mix()
 )
-
     components = [
         load(
             BrusilovskyEoSComponent;

--- a/src/dbload.jl
+++ b/src/dbload.jl
@@ -116,7 +116,7 @@ function __load_brusilovsky_comp__(
 end
 
 """
-    load(BrusilovskyEoSComponent; name::AbstractString[, component_dbs])
+    load(BrusilovskyEoSMixture; name::AbstractString[, component_dbs])
 
 Return `BrusilovskyEoSMixture` by loading parameters for individual substances named `names`
 from `component_dbs` and their interaction parameters from `mix_eos_db`.
@@ -140,7 +140,7 @@ function load(
     component_dbs = (Data.martinez(), Data.brusilovsky_comp()),
     mix_eos_db::MixtureDatabase = Data.brusilovsky_mix()
 )
-    
+
     components = [
         load(
             BrusilovskyEoSComponent;

--- a/src/dbload.jl
+++ b/src/dbload.jl
@@ -9,8 +9,8 @@ Return `BrusilovskyEoSComponent` named `name` with parameters from `component_db
 - the first argument is `BrusilovskyEoSComponent`
 
 # Keywords
-- name::AbstractString: the component name
-- component_dbs: an iterable of `ComponentDatabase` objects (by default,
+- `name::AbstractString`: the component name
+- `component_dbs`: an iterable of `ComponentDatabase` objects (by default,
 (Data.martinez(), Data.brusilovsky_comp()))
 
 # Returns
@@ -115,7 +115,7 @@ function __load_brusilovsky_comp__(
 end
 
 """
-    load(BrusilovskyEoSMixture; name::AbstractString[, component_dbs])
+    load(BrusilovskyEoSMixture; names[, component_dbs])
 
 Return `BrusilovskyEoSMixture` by loading parameters for individual substances named `names`
 from `component_dbs` and their interaction parameters from `mix_eos_db`.
@@ -124,10 +124,10 @@ from `component_dbs` and their interaction parameters from `mix_eos_db`.
 - the first argument is `BrusilovskyEoSMixture`
 
 # Keywords
-- names::AbstractString: the names of components to load
-- component_dbs: an iterable of `ComponentDatabase` objects (by default,
+- `names`: an iterable of `AbstractString`s containing the names of components to load
+- `component_dbs`: an iterable of `ComponentDatabase` objects (by default,
 `(Data.martinez(), Data.brusilovsky_comp())`)
-- mix_eos_db::MixtureDatabase: the database with the cross-component interaction
+- `mix_eos_db::MixtureDatabase`: the database with the cross-component interaction
 parameters (by default, `Data.brusilovsky_mix()`)
 
 # Returns

--- a/src/dbload.jl
+++ b/src/dbload.jl
@@ -144,7 +144,8 @@ function load(
     components = [
         load(
             BrusilovskyEoSComponent;
-            name = name, component_dbs = component_dbs
+            name = name,
+            component_dbs = component_dbs
         ) for name in names
     ]
     corrections = getmatrix(mix_eos_db, names)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,3 @@
-export molar_mass, carbon_number, name, describe, load, components
 """
     molar_mass(c::AbstractEoSComponent)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -6,9 +6,9 @@ Return the molar mass of a component.
 function molar_mass end
 
 """
-    molar_mass(c::AbstractEoSComponent)
+    carbon_number(c::AbstractEoSComponent)
 
-Return the molar mass of a component.
+Return the number of carbons atoms in the hydrocarbon chain.
 """
 function carbon_number end
 
@@ -27,9 +27,9 @@ Return `Dict` of parameters. Useful for logging.
 function describe end
 
 """
-    load(::Type{T}; name::AbstractString, physdb::AbstractString) where {T<:AbstractEoSComponent}
+    load(::Type{T}; name::AbstractString, databases) where {T<:AbstractEoSComponent}
 
-Load component `::T` by its `name` and `physdb` from database.
+Load component `::T` by its `name` by joining the data on this species in `databases`.
 """
 function load end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -78,7 +78,8 @@ struct BrusilovskyEoSMixture{T} <: AbstractEoSMixture
     gij::Matrix{T} # linear    thermal binary interaction coefficient
     hij::Matrix{T} # quadratic thermal binary interaction coefficient
 
-    function BrusilovskyEoSMixture( ;
+    function BrusilovskyEoSMixture(
+        ;
         components::AbstractVector{BrusilovskyEoSComponent{T}},
         constant::AbstractMatrix,
         linear::AbstractMatrix,
@@ -116,4 +117,14 @@ function BrusilovskyThermoBuffer(mix::BrusilovskyEoSMixture{T}) where {T}
     return BrusilovskyThermoBuffer{T}(nc)
 end
 
+"""
+    thermo_buffer(mix)
+
+Create a buffer for intermediate calculations of mixture thermodynamic properties.
+
+For more info see ?pressure(mixture).
+
+See also: [`pressure`](@ref), [`log_c_activity`](@ref), [`log_c_activity!`](@ref),
+[`log_c_activity_wj`](@ref), [`log_c_activity_wj!`](@ref)
+"""
 thermo_buffer(mix::BrusilovskyEoSMixture) = BrusilovskyThermoBuffer(mix)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-export BrusilovskyEoSComponent, BrusilovskyEoSMixture
+export BrusilovskyEoSComponent, BrusilovskyEoSMixture, thermo_buffer
 
 abstract type AbstractEoSComponent end
 
@@ -117,3 +117,5 @@ function BrusilovskyThermoBuffer(mix::BrusilovskyEoSMixture{T}) where {T}
     nc = ncomponents(mix)
     return BrusilovskyThermoBuffer{T}(nc)
 end
+
+thermo_buffer(mix::BrusilovskyEoSMixture) = BrusilovskyThermoBuffer(mix)

--- a/src/types.jl
+++ b/src/types.jl
@@ -122,8 +122,6 @@ end
 
 Create a buffer for intermediate calculations of mixture thermodynamic properties.
 
-For more info see ?pressure(mixture).
-
 See also: [`pressure`](@ref), [`log_c_activity`](@ref), [`log_c_activity!`](@ref),
 [`log_c_activity_wj`](@ref), [`log_c_activity_wj!`](@ref)
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,3 @@
-export BrusilovskyEoSComponent, BrusilovskyEoSMixture, thermo_buffer
-
 abstract type AbstractEoSComponent end
 
 abstract type AbstractEoSMixture end

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,7 +9,7 @@ const NothingOrT{T} = Union{Nothing,T}
 struct BrusilovskyEoSComponent{T<:Number} <: AbstractEoSComponent
     # meta information
     name::String
-    
+
     # physical parameters
     Pc::T  # critical pressure
     acentric_factor::T
@@ -23,7 +23,7 @@ struct BrusilovskyEoSComponent{T<:Number} <: AbstractEoSComponent
     c::T      # explicit coefficient of the eos c
     d::T      # explicit coefficient of the eos d
     Psi::T    # primary coefficient of the eos - \Psi
-    
+
     function BrusilovskyEoSComponent{T}(
         ;
         name::AbstractString="No Name",
@@ -91,4 +91,29 @@ struct BrusilovskyEoSMixture{T} <: AbstractEoSMixture
     end
 end
 
-@inline Base.@propagate_inbounds Base.getindex(mix::BrusilovskyEoSMixture, i::Integer) = mix.components[i]
+@inline Base.@propagate_inbounds function Base.getindex(
+    mix::BrusilovskyEoSMixture,
+    i::Integer
+)
+    return mix.components[i]
+end
+
+struct BrusilovskyThermoBuffer{T}
+    matr::Matrix{T}
+    vec1::Vector{T}
+    vec2::Vector{T}
+end
+
+function BrusilovskyThermoBuffer{T}(n::Integer) where {T}
+    matr = Matrix{T}(undef, n, n)
+    vec1 = similar(matr, (n,))
+    vec2 = similar(vec1)
+    return BrusilovskyThermoBuffer{T}(matr, vec1, vec2)
+end
+
+BrusilovskyThermoBuffer(n::Integer) = BrusilovskyThermoBuffer{Float64}(n)
+
+function BrusilovskyThermoBuffer(mix::BrusilovskyEoSMixture{T}) where {T}
+    nc = ncomponents(mix)
+    return BrusilovskyThermoBuffer{T}(nc)
+end

--- a/src/vt_stability.jl
+++ b/src/vt_stability.jl
@@ -1,7 +1,6 @@
 #=
 VT stability algorithm
 =#
-export vt_stability, vt_stability_buffer
 
 using DescentMethods
 

--- a/test/basic_thermo.jl
+++ b/test/basic_thermo.jl
@@ -1,22 +1,31 @@
 @testset "Basic thermo" begin
     C₁C₅ = CubicEoS.load(BrusilovskyEoSMixture; names=("methane", "n-pentane"))
-
-    @testset "eos_parameters" begin
-        nmol = [0.8, 1-0.8]
-        RT = 300 * CubicEoS.GAS_CONSTANT_SI
-        @testset "Calls w/wo buffers" begin
-            buffer_st = thermo_buffer(C₁C₅)
-            buffer_nt = (ai=similar(nmol), aij=zeros((length(nmol), length(nmol))))
-            buffer_dict = Dict(:ai => similar(nmol), :aij => zeros((length(nmol), length(nmol))))
-            # no buffer vs buffer struct
-            @test CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, nmol, RT; buf=buffer_st)
-            # no buffer vs buffer namedtuple
-            @test CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, nmol, RT; buf=buffer_nt)
-            # no buffer vs buffer dict
-            @test CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, nmol, RT; buf=buffer_dict)
+    RT = 300 * CubicEoS.GAS_CONSTANT_SI
+    @testset "Calls w/wo buffers" begin
+        nc = ncomponents(C₁C₅)
+        buffer_st = thermo_buffer(C₁C₅)
+        buffer_nt = (ai=zeros(nc), aij=zeros((nc, nc)))
+        buffer_dict = Dict(:ai => zeros(nc), :aij => zeros((nc, nc)))
+        # the following tests are grouped by
+        # 1. no buffer vs buffer struct
+        # 2. no buffer vs buffer namedtuple
+        # 3. no buffer vs buffer dict
+        N = 2 * [0.8, 1-0.8]
+        V = 2.5
+        for buffer in (buffer_st, buffer_nt, buffer_dict)
+            @test CubicEoS.eos_parameters(C₁C₅, N, RT) == CubicEoS.eos_parameters(C₁C₅, N, RT; buf=buffer)
+            @test pressure(C₁C₅, N, V, RT) == pressure(C₁C₅, N, V, RT; buf=buffer)
         end
+    end
+    @testset "Pressure" begin
         @testset "Homogeneity" begin
-            @test_skip CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, 5 * nmol, RT)
+            V = 1
+            χ = [0.8, 1-0.8]
+            for ∑N in 0.1:0.2:1.9
+                N = χ * ∑N
+                υ = V / ∑N
+                @test pressure(C₁C₅, N, V, RT) ≈ pressure(C₁C₅, χ, υ, RT)
+            end
         end
     end
 end

--- a/test/basic_thermo.jl
+++ b/test/basic_thermo.jl
@@ -1,0 +1,5 @@
+@testset "Basic thermo" begin
+    @testset "eos_parameters" begin
+        @test 1 == 1
+    end
+end

--- a/test/basic_thermo.jl
+++ b/test/basic_thermo.jl
@@ -1,5 +1,22 @@
 @testset "Basic thermo" begin
+    C₁C₅ = CubicEoS.load(BrusilovskyEoSMixture; names=("methane", "n-pentane"))
+
     @testset "eos_parameters" begin
-        @test 1 == 1
+        nmol = [0.8, 1-0.8]
+        RT = 300 * CubicEoS.GAS_CONSTANT_SI
+        @testset "Calls w/wo buffers" begin
+            buffer_st = thermo_buffer(C₁C₅)
+            buffer_nt = (ai=similar(nmol), aij=zeros((length(nmol), length(nmol))))
+            buffer_dict = Dict(:ai => similar(nmol), :aij => zeros((length(nmol), length(nmol))))
+            # no buffer vs buffer struct
+            @test CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, nmol, RT; buf=buffer_st)
+            # no buffer vs buffer namedtuple
+            @test CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, nmol, RT; buf=buffer_nt)
+            # no buffer vs buffer dict
+            @test CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, nmol, RT; buf=buffer_dict)
+        end
+        @testset "Homogeneity" begin
+            @test_skip CubicEoS.eos_parameters(C₁C₅, nmol, RT) == CubicEoS.eos_parameters(C₁C₅, 5 * nmol, RT)
+        end
     end
 end

--- a/test/c1c4.jl
+++ b/test/c1c4.jl
@@ -55,7 +55,7 @@ function helmholtz(nmol, vol)
     return f
 end
 
-println("Helmholtz energy: ", helmholtz(nmol))
+println("Helmholtz energy: ", helmholtz(nmol, 2.0))
 
 nmol1 = nmol .+ (1, 0)
 println("Approx. chemical potential: ", helmholtz(nmol1, 2.0) - helmholtz(nmol, 2.0))

--- a/test/c1c4.jl
+++ b/test/c1c4.jl
@@ -36,22 +36,20 @@ c1c4mix = BrusilovskyEoSMixture(
 
 nmol = [500., 500]
 
-_log_a = zeros(2)
-_ai = zeros(2)
-_aij = zeros(2, 2)
+thermo_buf = CubicEoS.BrusilovskyThermoBuffer(c1c4mix)
 
-p = pressure(c1c4mix, nmol, 2.0, 8.314 * 300; ai = _ai, aij = _aij)
+p = pressure(c1c4mix, nmol, 2.0, 8.314 * 300; buf = thermo_buf)
 println("Pressure: ", p, " Pa")
 
 function log_a(mix, nmol, vol, RT)
-    return CubicEoS.log_activity(mix, nmol, vol, RT; ai = _ai, aij = _aij)
+    return CubicEoS.log_c_activity(mix, nmol, vol, RT; buf = thermo_buf)
 end
 
 chempot(nmol) = 8.314 .* 300 .* (log.(nmol) .+ log_a(c1c4mix, nmol, 2.0, 8.314*300))
 
 function helmholtz(nmol, vol)
     f = sum(nmol .* chempot(nmol))
-    f -= vol * pressure(c1c4mix, nmol, vol, 8.314 * 300; ai = _ai, aij = _aij)
+    f -= vol * pressure(c1c4mix, nmol, vol, 8.314 * 300; buf = thermo_buf)
     return f
 end
 
@@ -64,7 +62,7 @@ println("Chemical potential: ", chempot(nmol))
 
 (log_a(c1c4mix, nmol1, 2.0, 8.314*300) - log_a(c1c4mix, nmol, 2.0, 8.314*300)) |> println
 
-CubicEoS.log_activity_wj(
+CubicEoS.log_c_activity_wj(
     c1c4mix,
     nmol,
     2.0,

--- a/test/c1c4.jl
+++ b/test/c1c4.jl
@@ -24,49 +24,49 @@ c4h10 = BrusilovskyEoSComponent(
 
 c1c4cij = [
     0 0.01
-    0.01 0]
+    0.01 0
+]
 
-c1c4mix = BrusilovskyEoSMixture(components = [ch4, c4h10],
-                                constant = c1c4cij,
-                                linear = zeros(2,2),
-                                quadratic = zeros(2,2))
-
-c1c4_chem_mix = CubicEoS.ChemPotentialMixture(c1c4mix)
+c1c4mix = BrusilovskyEoSMixture(
+    components = [ch4, c4h10],
+    constant = c1c4cij,
+    linear = zeros(2,2),
+    quadratic = zeros(2,2)
+)
 
 nmol = [500., 500]
 
-p = pressure(c1c4mix, nmol, 2.0, 8.314 * 300)
+_log_a = zeros(2)
+_ai = zeros(2)
+_aij = zeros(2, 2)
+
+p = pressure(c1c4mix, nmol, 2.0, 8.314 * 300; ai = _ai, aij = _aij)
 println("Pressure: ", p, " Pa")
 
-log_a = zeros(2)
-ai = zeros(2)
-aij = zeros(2, 2)
+function log_a(mix, nmol, vol, RT)
+    return CubicEoS.log_activity(mix, nmol, vol, RT; ai = _ai, aij = _aij)
+end
 
-chempot(nmol) = 8.314 .* 300 .* (log.(nmol) .+ 
-                                 CubicEoS.log_activity!(c1c4_chem_mix, 
-                                                        nmol, 
-                                                        2.0, 
-                                                        8.314*300))
-helmholtz(nmol) = sum(nmol .* chempot(nmol)) - CubicEoS.pressure!(c1c4_chem_mix, nmol, 2.0, 8.314 * 300)
+chempot(nmol) = 8.314 .* 300 .* (log.(nmol) .+ log_a(c1c4mix, nmol, 2.0, 8.314*300))
+
+function helmholtz(nmol, vol)
+    f = sum(nmol .* chempot(nmol))
+    f -= vol * pressure(c1c4mix, nmol, vol, 8.314 * 300; ai = _ai, aij = _aij)
+    return f
+end
+
 println("Helmholtz energy: ", helmholtz(nmol))
 
 nmol1 = nmol .+ (1, 0)
-println("Approx. chemical potential: ", helmholtz(nmol1) - helmholtz(nmol))
+println("Approx. chemical potential: ", helmholtz(nmol1, 2.0) - helmholtz(nmol, 2.0))
 
 println("Chemical potential: ", chempot(nmol))
 
-(CubicEoS.log_activity(
-c1c4mix, 
-nmol1, 
-2.0, 
-8.314*300) - CubicEoS.log_activity(
-    c1c4mix, 
-    nmol, 
-    2.0, 
-    8.314*300)) |> println
+(log_a(c1c4mix, nmol1, 2.0, 8.314*300) - log_a(c1c4mix, nmol, 2.0, 8.314*300)) |> println
 
-CubicEoS.log_activity_wj!(
-c1c4_chem_mix, 
-nmol, 
-2.0, 
-8.314*300)
+CubicEoS.log_activity_wj(
+    c1c4mix,
+    nmol,
+    2.0,
+    8.314*300
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,18 @@
-include("dbload.jl")
+using CubicEoS
+using CubicEoSDatabase
+using Test
+
+
+#= Utilities =#
+
+"Non-recursively compare field values of `x` and `y`."
+function compare_structs(x::T, y::T) where {T}
+    for field in fieldnames(T)
+        @test getfield(x, field) == getfield(y, field)
+    end
+end
+
+
+@testset "CubicEoS.jl" begin
+    include("dbload.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,5 @@ end
 
 @testset "CubicEoS.jl" begin
     include("dbload.jl")
+    include("basic_thermo.jl")
 end


### PR DESCRIPTION
Use specialized structs for buffers to calculate pressure and chemical potentials.
The chemical potential-related functions have two variants: overwriting the user-provided arrays or create them anew.