### PR TITLE
Change component storage in mixtures to `StructVector`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 CubicEoSDatabase = "8742253c-1987-415f-b31d-1ec9670d9ed7"
 DescentMethods = "f4becde8-b16e-4b5a-8f91-16ef0c22c8bc"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [compat]
 julia = "1.4"

--- a/src/basic_thermo.jl
+++ b/src/basic_thermo.jl
@@ -157,18 +157,18 @@ function __eos_parameters_impl__(
     ai, aij = auxv, auxm
 
     comp = mixture.components
-    ai .= a_coef.(comp, RT)
+    psi = comp.Psi
+    ac = comp.ac
+    @. ai = ac * (1 + psi * (1 - sqrt(RT / comp.RTc)) )^2
 
-    Bm = Cm = Dm = zero(T)
-    @inbounds for i in eachindex(nmol, comp)
-        Bm += nmol[i] * comp[i].b
-        Cm += nmol[i] * comp[i].c
-        Dm += nmol[i] * comp[i].d
-    end
+    bi, ci, di = comp.b, comp.c, comp.d
+    Bm = dot(nmol, bi)
+    Cm = dot(nmol, ci)
+    Dm = dot(nmol, di)
 
-    temp = RT / GAS_CONSTANT_SI - 273.16
+    tempC = RT / GAS_CONSTANT_SI - 273.16
     eij, gij, hij = mixture.eij, mixture.gij, mixture.hij
-    aij .= (one(T) .- (eij .+ temp .* (gij .+ temp .* hij))) .* sqrt.(ai .* ai')
+    aij .= (one(T) .- (eij .+ tempC .* (gij .+ tempC .* hij))) .* sqrt.(ai .* ai')
     Am = dot(nmol, aij, nmol)  # Am = nmolᵀ aij nmol
     return Am, Bm, Cm, Dm, aij
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,5 @@
+using StructArrays
+
 abstract type AbstractEoSComponent end
 
 abstract type AbstractEoSMixture end
@@ -72,7 +74,7 @@ Mixture
 =#
 
 struct BrusilovskyEoSMixture{T} <: AbstractEoSMixture
-    components::Vector{BrusilovskyEoSComponent{T}}
+    components::StructVector{BrusilovskyEoSComponent{T}}
 
     eij::Matrix{T} # constant  thermal binary interaction coefficient
     gij::Matrix{T} # linear    thermal binary interaction coefficient
@@ -86,7 +88,7 @@ struct BrusilovskyEoSMixture{T} <: AbstractEoSMixture
         quadratic::AbstractMatrix,
         kw...
     ) where {T}
-        new{T}(components, constant, linear, quadratic)
+        new{T}(StructVector(components), constant, linear, quadratic)
     end
 end
 


### PR DESCRIPTION
This changes the memory layout of a mixture so that the component EoS parameters `ac`, `b`, `c`, `d` are now stored in contiguous arrays. That should be in theory more efficient in terms of speed, plus it simplifies certain parts of the code.